### PR TITLE
fix: linux cross-build require CFLAGS_FOR_BUILD

### DIFF
--- a/build-hnp/bash/Makefile
+++ b/build-hnp/bash/Makefile
@@ -1,5 +1,8 @@
 include ../utils/Makefrag
 
+# required by mkbuiltin cross-build process when using gcc 13+
+export CFLAGS_FOR_BUILD := -std=gnu17
+
 all: download/bash-5.2.37.tar.gz
 	rm -rf temp build
 	mkdir -p temp build


### PR DESCRIPTION
building `bash-5.2` on linux leads to these errors, see this [issue](https://github.com/openwrt/packages/issues/26469).

adding `CFLAGS_FOR_BUILD := -std=gnu17` works for me.