### PR TITLE
Complete path relocation of qemu-vroot

### DIFF
--- a/build-hnp/qemu-vroot/0013-Complete-path-relocation.patch
+++ b/build-hnp/qemu-vroot/0013-Complete-path-relocation.patch
@@ -1,0 +1,205 @@
+From f544be295a54bba51a95bd302c21bd57fd446ee8 Mon Sep 17 00:00:00 2001
+From: hackeris <hackeris@qq.com>
+Date: Fri, 11 Jul 2025 23:55:35 +0800
+Subject: [PATCH 13/13] Complete path relocation
+
+---
+ include/qemu/path.h  |  1 +
+ linux-user/syscall.c | 20 +++++++++--------
+ util/path.c          | 51 +++++++++++++++++++++++++++++---------------
+ 3 files changed, 46 insertions(+), 26 deletions(-)
+
+diff --git a/include/qemu/path.h b/include/qemu/path.h
+index 4f6d7f1..db98672 100644
+--- a/include/qemu/path.h
++++ b/include/qemu/path.h
+@@ -3,6 +3,7 @@
+
+ void init_paths(const char *prefix);
+ const char *path(const char *pathname);
++const char *pathat(int dirfd, const char *pathname);
+ char* resolve_with_path_env(const char* path_env, const char* name, char* out);
+ char* resolve_abs_with_cwd(const char* path, char* out);
+
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index f762e2b..4c317e7 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -6114,6 +6114,8 @@ static int do_execve(char *p, const char **argp, const char **envp) {
+             char prog[PATH_MAX] = {0};
+             if (resolve_with_path_env(path_value, new_argv[idx_guest_program], prog)) {
+                 new_argv[idx_guest_program] = path(prog);
++            } else {
++                new_argv[idx_guest_program] = path(p);
+             }
+         }
+     } else {
+@@ -7170,7 +7172,7 @@ static abi_long do_name_to_handle_at(abi_long dirfd, abi_long pathname,
+     fh = g_malloc0(total_size);
+     fh->handle_bytes = size;
+
+-    ret = get_errno(name_to_handle_at(dirfd, path(name), fh, &mid, flags));
++    ret = get_errno(name_to_handle_at(dirfd, pathat(dirfd, name), fh, &mid, flags));
+     unlock_user(name, pathname, 0);
+
+     /* man name_to_handle_at(2):
+@@ -7569,7 +7571,7 @@ static int do_openat(void *cpu_env, int dirfd, const char *pathname, int flags,
+         return fd;
+     }
+
+-    return safe_openat(dirfd, path(pathname), flags, mode);
++    return safe_openat(dirfd, pathat(dirfd, pathname), flags, mode);
+ }
+
+ #define TIMER_MAGIC 0x0caf0000
+@@ -7949,7 +7951,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
+              * before the execve completes and makes it the other
+              * program's problem.
+              */
+-            ret = get_errno(do_execve(path(p), argp, envp));
++            ret = get_errno(do_execve(p, argp, envp));
+             unlock_user(p, arg1, 0);
+
+             goto execve_end;
+@@ -8176,7 +8178,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
+             if (!(p = lock_user_string(arg2))) {
+                 return -TARGET_EFAULT;
+             }
+-            ret = get_errno(futimesat(arg1, path(p), tvp));
++            ret = get_errno(futimesat(arg1, pathat(arg1, p), tvp));
+             unlock_user(p, arg2, 0);
+         }
+         return ret;
+@@ -9126,7 +9128,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
+                 ret = temp == NULL ? get_errno(-1) : strlen(real) ;
+                 snprintf((char *)p2, arg4, "%s", real);
+             } else {
+-                ret = get_errno(readlinkat(arg1, path(p), p2, arg4));
++                ret = get_errno(readlinkat(arg1, pathat(arg1, p), p2, arg4));
+             }
+             unlock_user(p2, arg3, ret);
+             unlock_user(p, arg2, 0);
+@@ -10772,7 +10774,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
+         if (!(p = lock_user_string(arg2))) {
+             return -TARGET_EFAULT;
+         }
+-        ret = get_errno(fstatat(arg1, path(p), &st, arg4));
++        ret = get_errno(fstatat(arg1, pathat(arg1, p), &st, arg4));
+         unlock_user(p, arg2, 0);
+         if (!is_error(ret))
+             ret = host_to_target_stat64(cpu_env, arg3, &st);
+@@ -10811,7 +10813,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
+                 }
+             }
+ #endif
+-            ret = get_errno(fstatat(dirfd, path(p), &st, flags));
++            ret = get_errno(fstatat(dirfd, pathat(dirfd, p), &st, flags));
+             unlock_user(p, arg2, 0);
+
+             if (!is_error(ret)) {
+@@ -11796,7 +11798,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
+                 if (!(p = lock_user_string(arg2))) {
+                     return -TARGET_EFAULT;
+                 }
+-                ret = get_errno(sys_utimensat(arg1, path(p), tsp, arg4));
++                ret = get_errno(sys_utimensat(arg1, pathat(arg1, p), tsp, arg4));
+                 unlock_user(p, arg2, 0);
+             }
+         }
+@@ -11832,7 +11834,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
+ #if defined(TARGET_NR_inotify_add_watch) && defined(__NR_inotify_add_watch)
+     case TARGET_NR_inotify_add_watch:
+         p = lock_user_string(arg2);
+-        ret = get_errno(sys_inotify_add_watch(arg1, path(p), arg3));
++        ret = get_errno(sys_inotify_add_watch(arg1, pathat(arg1, p), arg3));
+         unlock_user(p, arg2, 0);
+         return ret;
+ #endif
+diff --git a/util/path.c b/util/path.c
+index 76ab896..3535851 100644
+--- a/util/path.c
++++ b/util/path.c
+@@ -34,21 +34,38 @@ void init_paths(const char *prefix)
+     qemu_mutex_init(&strtok_lock);
+ }
+
+-/* Look for path in emulation dir, otherwise return name. */
+-const char *path(const char *name)
++static const char *relocate_path(const char *name, bool keep_relative_path)
+ {
+     gpointer key, value;
+     const char *ret;
+
+     char abspath[PATH_MAX];
+
+-    if (!base || !name || name[0] != '/') {
++    if (!base || !name) {
++        //  rnvalid
++        return name;
++    } else if (strcmp(name, "/") == 0) {
++        //  root
++        return base;
++    } else if (name[0] != '/') {
++        //  relative
++        if (keep_relative_path) {
++            return name;
++        }
+         getcwd(abspath, sizeof(abspath));
++        if (strstr(abspath, base) == &abspath[0]) {
++            //  already at rootfs
++            return name;
++        }
+         strcat(abspath, "/");
+         strcat(abspath, name);
+-    } else if (strcmp(name, "/") == 0) {
+-        return base;
+     } else {
++        //  absolute
++        if (strstr(name, "/proc/") == name
++            || strcmp(name, "/etc/resolv.conf") == 0) {
++            //  reuse hosts
++            return name;
++        }
+         strcpy(abspath, name);
+     }
+
+@@ -60,24 +77,24 @@ const char *path(const char *name)
+     } else {
+         char *save = g_strdup(abspath);
+         char *full = g_build_filename(base, abspath, NULL);
+-
+-        /* Look for the path; record the result, pass or fail.  */
+-        if (access(full, F_OK) == 0) {
+-            /* Exists.  */
+-            g_hash_table_insert(hash, save, full);
+-            ret = full;
+-        } else {
+-            /* Does not exist.  */
+-            g_free(full);
+-            g_hash_table_insert(hash, save, NULL);
+-            ret = name;
+-        }
++        g_hash_table_insert(hash, save, full);
++        ret = full;
+     }
+
+     qemu_mutex_unlock(&lock);
+     return ret;
+ }
+
++const char *pathat(int dirfd, const char *name) {
++    const int keep_relative_path = dirfd == AT_FDCWD ? false : true;
++    return relocate_path(name, keep_relative_path);
++}
++
++/* Look for path in emulation dir, otherwise return name. */
++const char *path(const char *name) {
++    return relocate_path(name, false);
++}
++
+ char *resolve_with_path_env(const char *path_env, const char *name, char *out) {
+
+     if (!path_env || !name || !out) return NULL;
+--
+2.49.0.windows.1
+

--- a/build-hnp/qemu-vroot/Makefile
+++ b/build-hnp/qemu-vroot/Makefile
@@ -15,6 +15,7 @@ all: download/qemu-5.0
 	cd temp/qemu-5.0 && git apply ../../0010-Support-specify-relative-virtual-root-directory.patch
 	cd temp/qemu-5.0 && git apply ../../0011-Disable-mount-proc-filesystem.patch
 	cd temp/qemu-5.0 && git apply ../../0012-Disable-umount2-proc-filesystem.patch
+	cd temp/qemu-5.0 && git apply ../../0013-Complete-path-relocation.patch
 	cd temp/qemu-5.0 && \
 	PKG_CONFIG=$(shell which pkg-config) \
 	PKG_CONFIG_PATH= \


### PR DESCRIPTION
Fixed some errors from `apk add` by completing path relocation of qemu-vroot.

Now `apk add` and `apk del` works(not completely) and alpine packages can be installed/uninstalled by apk running in qemu-vroot.

![1d93d885a440078fd1e94585a120c958](https://github.com/user-attachments/assets/a1c8aab9-7395-49c3-882b-e51c926f51c7)
