### PR TITLE
support mount root of host to guest

### DIFF
--- a/build-hnp/qemu-vroot/0008-forward-dev-access-to-host.patch
+++ b/build-hnp/qemu-vroot/0008-forward-dev-access-to-host.patch
@@ -1,0 +1,27 @@
+From 8dbd5728dfb26ffde96237f8938f8506ea5d6d48 Mon Sep 17 00:00:00 2001
+From: hackeris <hackeris@qq.com>
+Date: Thu, 14 Aug 2025 00:06:09 +0800
+Subject: [PATCH 8/8] forward /dev access to host
+
+---
+ util/path.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/util/path.c b/util/path.c
+index f602d351072..a2dcc178476 100644
+--- a/util/path.c
++++ b/util/path.c
+@@ -48,7 +48,9 @@ static bool skip_relocation(const char* name)
+         || strcmp(name, "/sys") == 0
+         || strcmp(name, "/etc/resolv.conf") == 0
+         || strcmp(name, "/etc/passwd") == 0
+-        || strcmp(name, "/dev/null") == 0;
++        || strcmp(name, "/dev") == 0
++        || strstr(name, "/dev/") == name
++    ;
+ }
+ 
+ const char* do_relocate_path(const char* name, char* out)
+-- 
+2.43.0
+

--- a/build-hnp/qemu-vroot/0009-support-mount-root-of-host-to-guest.patch
+++ b/build-hnp/qemu-vroot/0009-support-mount-root-of-host-to-guest.patch
@@ -1,0 +1,200 @@
+From 958780aa34480b0fe38e01857e57f010c1c3206d Mon Sep 17 00:00:00 2001
+From: hackeris <hackeris@qq.com>
+Date: Mon, 18 Aug 2025 01:52:26 +0800
+Subject: [PATCH 9/9] support mount root of host to guest
+
+---
+ include/qemu/path.h |   4 +-
+ util/path.c         | 101 ++++++++++++++++++++++++++------------------
+ 2 files changed, 63 insertions(+), 42 deletions(-)
+
+diff --git a/include/qemu/path.h b/include/qemu/path.h
+index 5784bb92206..21e4606dd68 100644
+--- a/include/qemu/path.h
++++ b/include/qemu/path.h
+@@ -2,8 +2,8 @@
+ #define QEMU_PATH_H
+ 
+ void init_paths(const char *prefix);
+-char *relocate_path_at(int dirfd, const char *name, char *out, bool follow_symlink);
+-char *restore_path(const char* name, char* out);
++char *relocate_path_at(int host_dirfd, const char *guest_path, char *out, bool follow_symlink);
++char *restore_path(const char* host_path, char* out);
+ char* resolve_with_path_env(const char* path_env, int dirfd, const char* name, char* out);
+ char* resolve_abs_with_cwd(const char* path, char* out);
+ 
+diff --git a/util/path.c b/util/path.c
+index a2dcc178476..b8787076c32 100644
+--- a/util/path.c
++++ b/util/path.c
+@@ -53,62 +53,79 @@ static bool skip_relocation(const char* name)
+     ;
+ }
+ 
+-const char* do_relocate_path(const char* name, char* out)
++const char* do_relocate_path(const char* guest, char* out)
+ {
+-    if (!base || !name) {
++    if (!base || !guest) {
+         //  invalid
+         goto use_original;
+     }
+-    if (skip_relocation(name)) {
++    if (skip_relocation(guest)) {
+         //  reuse hosts
+         goto use_original;
+     }
+-    if (strstr(name, base) == name) {
++    if (strstr(guest, base) == guest) {
+         //  already at rootfs
+         goto use_original;
+     }
+ 
+-    char abspath[PATH_MAX];
+-    if (name[0] != '/') {
++    char host_path[PATH_MAX];
++    if (guest[0] != '/') {
+         //  relative to absolute
+-        getcwd(abspath, sizeof(abspath));
+-        strcat(abspath, "/");
+-        strcat(abspath, name);
++        getcwd(host_path, sizeof(host_path));
++        strcat(host_path, "/");
++        strcat(host_path, guest);
+     }
+     else {
+-        //  absolute
+-        strcpy(abspath, base);
+-        strcat(abspath, "/");
+-        strcat(abspath, name);
++        if (strcmp(guest, "/mnt/host-root") == 0) {
++            //  root of host
++            strcpy(host_path, "/");
++        }
++        else if (strstr(guest, "/mnt/host-root/") == guest) {
++            //  remove prefix
++            strcpy(host_path, guest + strlen("/mnt/host-root"));
++        }
++        else {
++            //  absolute
++            strcpy(host_path, base);
++            strcat(host_path, "/");
++            strcat(host_path, guest);
++        }
+     }
+ 
+-    strcpy(out, abspath);
++    strcpy(out, host_path);
+     return out;
+ 
+ use_original:
+-    strcpy(out, name);
++    strcpy(out, guest);
+     return out;
+ }
+ 
+-static bool convert_to_abs_path(int dirfd, const char* path, char* out)
++static bool convert_to_abs_path(int host_dirfd, const char* guest_path, char* out)
+ {
+-    if (dirfd == AT_FDCWD || path[0] == '/') {
+-        do_relocate_path(path, out);
++    if (host_dirfd == AT_FDCWD || guest_path[0] == '/') {
++        do_relocate_path(guest_path, out);
+         return true;
+     }
+ 
+-    char dir_path[PATH_MAX] = {0};
+-    char tmp[PATH_MAX];
+-    snprintf(tmp, sizeof(tmp), "/proc/self/fd/%d", dirfd);
+-    ssize_t len = readlink(tmp, dir_path, sizeof(dir_path) - 1);
++    char self_fd[PATH_MAX];
++    snprintf(self_fd, sizeof(self_fd), "/proc/self/fd/%d", host_dirfd);
++    char host_path[PATH_MAX] = {0};
++    ssize_t len = readlink(self_fd, host_path, sizeof(host_path) - 1);
+     if (len <= 0) {
+         return false;
+     }
+-    dir_path[len] = '\0';
++    host_path[len] = '\0';
+ 
+-    char full_path[PATH_MAX];
+-    snprintf(full_path, sizeof(full_path), "%s/%s", dir_path, path);
+-    do_relocate_path(full_path, out);
++    if (strstr(host_path, base) != &host_path[0]) {
++        //  not in base
++        char host_full_path[PATH_MAX];
++        snprintf(host_full_path, sizeof(host_full_path), "%s/%s", host_path, guest_path);
++        return true;
++    }
++
++    char host_full_path[PATH_MAX];
++    snprintf(host_full_path, sizeof(host_full_path), "%s/%s", host_path, guest_path);
++    do_relocate_path(host_full_path, out);
+     return true;
+ }
+ 
+@@ -304,29 +321,29 @@ static bool real_exists(const char* path)
+     return !S_ISLNK(s.st_mode);
+ }
+ 
+-char* relocate_path_at(int dirfd, const char* name, char* out, bool follow_symlink)
++char* relocate_path_at(int host_dirfd, const char* guest_path, char* out, bool follow_symlink)
+ {
+-    char tmp[PATH_MAX];
+-    convert_to_abs_path(dirfd, name, tmp);
++    char host_full_path[PATH_MAX];
++    convert_to_abs_path(host_dirfd, guest_path, host_full_path);
+ 
+     if (follow_symlink
+-        && !skip_relocation(name)
+-        && !real_exists(tmp)) {
+-        char* res = readpath_with_relocation(tmp, out);
++        && !skip_relocation(guest_path)
++        && !real_exists(host_full_path)) {
++        char* res = readpath_with_relocation(host_full_path, out);
+         if (!res) {
+-            strcpy(out, tmp);
++            strcpy(out, host_full_path);
+         }
+     }
+     else {
+-        strcpy(out, tmp);
++        strcpy(out, host_full_path);
+     }
+ 
+     return out;
+ }
+ 
+-char* restore_path(const char* name, char* out)
++char* restore_path(const char* host_path, char* out)
+ {
+-    if (name[0] != '/') {
++    if (host_path[0] != '/') {
+         goto reuse;
+     }
+ 
+@@ -337,13 +354,17 @@ char* restore_path(const char* name, char* out)
+         strcat(buf_base, "/");
+     }
+ 
+-    if (strstr(name, buf_base) == name) {
+-        strcpy(out, name + strlen(buf_base) - 1);
+-        return out;
++    if (strstr(host_path, buf_base) == host_path) {
++        strcpy(out, host_path + strlen(buf_base) - 1);
+     }
++    else {
++        //  not in base
++        sprintf(out, "/mnt/host-root/%s", host_path);
++    }
++    return out;
+ 
+ reuse:
+-    strcpy(out, name);
++    strcpy(out, host_path);
+     return out;
+ }
+ 
+-- 
+2.43.0
+

--- a/build-hnp/qemu-vroot/Makefile
+++ b/build-hnp/qemu-vroot/Makefile
@@ -11,6 +11,8 @@ all: download/qemu-10
 	cd temp/qemu-10 && git apply ../../0005-fix-argv-for-geust-on-OHOS.patch
 	cd temp/qemu-10 && git apply ../../0006-support-redirecting-file-access-to-specified-root-fi.patch
 	cd temp/qemu-10 && git apply ../../0007-fix-jit-on-OHOS.patch
+	cd temp/qemu-10 && git apply ../../0008-forward-dev-access-to-host.patch
+	cd temp/qemu-10 && git apply ../../0009-support-mount-root-of-host-to-guest.patch
 	cd temp/qemu-10 && \
 	PKG_CONFIG=$(shell which pkg-config) \
 	PKG_CONFIG_PATH= \


### PR DESCRIPTION
root of host (`/`) can be mounted to guest at `/mnt/host-root`

![fa6bbf9265db877bf428134bbb39cb1b](https://github.com/user-attachments/assets/d158fabf-6c87-4756-baf2-87f8e74e1a4f)
