### PR TITLE
zlib: bump version

### DIFF
--- a/build-hnp/zlib/Makefile
+++ b/build-hnp/zlib/Makefile
@@ -2,9 +2,9 @@ include ../utils/Makefrag
 
 export uname := Linux
 
-SOURCE_URL = https://zlib.net/zlib-1.3.1.tar.gz
-SOURCE_FILE = zlib-1.3.1.tar.gz
-SOURCE_DIR = zlib-1.3.1
+SOURCE_URL = https://zlib.net/zlib-1.3.2.tar.gz
+SOURCE_FILE = zlib-1.3.2.tar.gz
+SOURCE_DIR = zlib-1.3.2
 CONFIG_ARGS = --prefix=$(PREFIX) --enable-shared
 
 $(eval $(call define_autotools_package))


### PR DESCRIPTION
Since zlib no longer provides the 1.3.1 tarball, we should bump the version to 1.3.2.